### PR TITLE
fix: added tsguarder to the externals of rollup

### DIFF
--- a/rollup.config.cjs
+++ b/rollup.config.cjs
@@ -5,7 +5,7 @@ const filesize = require("rollup-plugin-filesize");
 const json = require("@rollup/plugin-json");
 
 const base = {
-  external: ["temp"],
+  external: ["temp", "tsguarder"],
   plugins: [
     typescript(),
     json(),


### PR DESCRIPTION
`tsguarder` was not included to the `external` dependencies in the rollup config and rollup included it to the emitted code